### PR TITLE
Skip request for file or directory when copying files

### DIFF
--- a/UtilityBats/CopyWhitelistedFiles.bat
+++ b/UtilityBats/CopyWhitelistedFiles.bat
@@ -15,7 +15,7 @@ for /F "tokens=*" %%g in (Configs/PakWhiteList.ini) do (
         robocopy "%ProjectFolder%\Saved\Cooked\WindowsNoEditor\%ProjectName%\Content\%%g" "Temp\PackageInput\Content\%%g" /MIR /ns /nc /nfl /ndl /np /njh /njs
     ) else if exist "%ProjectFolder%\Saved\Cooked\WindowsNoEditor\%ProjectName%\Content\%%g" (
         echo copying file %%g
-        xcopy "%ProjectFolder%\Saved\Cooked\WindowsNoEditor\%ProjectName%\Content\%%g" "Temp\PackageInput\Content\%%g"
+        echo F|xcopy "%ProjectFolder%\Saved\Cooked\WindowsNoEditor\%ProjectName%\Content\%%g" "Temp\PackageInput\Content\%%g"
     ) else (
         echo could not find %%g inside %ProjectName%\Content
     )


### PR DESCRIPTION
Let me know if there's a specific reason you chose not to implement this in the first place (aside from not getting round to it/not knowing how to skip).